### PR TITLE
ITOS-289: Adjust Adult 1 Indicator to match latest specs

### DIFF
--- a/reports/healthQual.jrxml
+++ b/reports/healthQual.jrxml
@@ -126,6 +126,7 @@ FROM isanteplus.patient p
     LEFT JOIN isanteplus.patient_dispensing pd ON p.patient_id = pd.patient_id,
     isanteplus.org_code_uid org
 WHERE pd.drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs)  -- ART treatment
+    AND p.vih_status = '1' -- HIV+ patient
     AND p.patient_id NOT IN (   -- Exclude discontinued (1667), transfer (159492)
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon

--- a/reports/healthQual.jrxml
+++ b/reports/healthQual.jrxml
@@ -99,7 +99,9 @@
 			AND p.patient_id IN ( SELECT pnv.patient_id FROM isanteplus.patient_visit pnv
 			WHERE pnv.patient_id = p.patient_id
             AND pnv.encounter_type IN (5, 11) -- Ord. Médicale OR Ord. médicale Pédiatrique
-			AND TIMESTAMPDIFF(DAY, DATE_ADD(STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d'), INTERVAL 1 MONTH), pnv.visit_date) <= 90)
+						AND (pnv.visit_date BETWEEN STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d') AND DATE_ADD(STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d'), INTERVAL 90 DAY)
+						OR pnv.visit_date BETWEEN DATE_SUB(STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d'), INTERVAL 90 DAY) AND STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d')))
+      AND arv.start_date BETWEEN SUBDATE(STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d'), INTERVAL 1 MONTH) AND STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d')
         ) THEN p.patient_id ELSE null END
     ) AS 'femaleNumerator',
     COUNT(
@@ -109,7 +111,9 @@
 			AND p.patient_id IN ( SELECT pnv.patient_id FROM isanteplus.patient_visit pnv
 			WHERE pnv.patient_id = p.patient_id
             AND pnv.encounter_type IN (5, 11) -- Ord. Médicale OR Ord. médicale Pédiatrique
-			AND TIMESTAMPDIFF(DAY, DATE_ADD(STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d'), INTERVAL 1 MONTH), pnv.visit_date) <= 90)
+						AND (pnv.visit_date BETWEEN STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d') AND DATE_ADD(STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d'), INTERVAL 90 DAY)
+						OR pnv.visit_date BETWEEN DATE_SUB(STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d'), INTERVAL 90 DAY) AND STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d')))
+      AND arv.start_date BETWEEN SUBDATE(STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d'), INTERVAL 1 MONTH) AND STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d')
         ) THEN p.patient_id ELSE null END
     ) AS 'maleNumerator',
     COUNT(
@@ -123,7 +127,8 @@
         ) THEN p.patient_id ELSE null END
     ) AS 'maleDenominator'
 FROM isanteplus.patient p
-    LEFT JOIN isanteplus.patient_dispensing pd ON p.patient_id = pd.patient_id,
+    LEFT JOIN isanteplus.patient_dispensing pd ON p.patient_id = pd.patient_id
+		INNER JOIN isanteplus.patient_status_arv arv ON p.patient_id = arv.patient_id,
     isanteplus.org_code_uid org
 WHERE pd.drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs)  -- ART treatment
     AND p.vih_status = '1' -- HIV+ patient
@@ -131,13 +136,10 @@ WHERE pd.drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs)  -- ART treatment
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon
         WHERE discon.reason IN (1667, 159492)
-    ) AND p.patient_id IN (
-        SELECT patient_id
-        FROM isanteplus.patient_status_arv
-        WHERE start_date BETWEEN SUBDATE(STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d'), INTERVAL 1 MONTH) AND STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d')
-    ) AND (p.birthdate IS NULL OR TIMESTAMPDIFF(YEAR, p.birthdate, STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d')) > 14) -- adult
-      AND p.organisation_uid = org.uid
-      AND FIND_IN_SET($P{organisationunits_uid}, org.path);]]>
+    )
+		AND (p.birthdate IS NULL OR TIMESTAMPDIFF(YEAR, p.birthdate, STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d')) > 14) -- adult
+    AND p.organisation_uid = org.uid
+    AND FIND_IN_SET($P{organisationunits_uid}, org.path);]]>
 		</queryString>
 		<field name="femaleNumerator" class="java.lang.Long"/>
 		<field name="maleNumerator" class="java.lang.Long"/>

--- a/reports/healthQual.jrxml
+++ b/reports/healthQual.jrxml
@@ -95,13 +95,21 @@
     COUNT(
         DISTINCT CASE WHEN (
             p.gender = 'F'
-            AND pd.next_dispensation_date >= STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d') -- still on ART
+			-- drug order form completed on date X. The date of the drug order form should not surpass the reporting period by more than 90 days.
+			AND p.patient_id IN ( SELECT pnv.patient_id FROM isanteplus.patient_visit pnv
+			WHERE pnv.patient_id = p.patient_id
+            AND pnv.encounter_type IN (5, 11) -- Ord. Médicale OR Ord. médicale Pédiatrique
+			AND TIMESTAMPDIFF(DAY, DATE_ADD(STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d'), INTERVAL 1 MONTH), pnv.visit_date) <= 90)
         ) THEN p.patient_id ELSE null END
     ) AS 'femaleNumerator',
     COUNT(
         DISTINCT CASE WHEN (
             p.gender = 'M'
-            AND pd.next_dispensation_date >= STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d') -- still on ART
+			-- drug order form completed on date X. The date of the drug order form should not surpass the reporting period by more than 90 days.
+			AND p.patient_id IN ( SELECT pnv.patient_id FROM isanteplus.patient_visit pnv
+			WHERE pnv.patient_id = p.patient_id
+            AND pnv.encounter_type IN (5, 11) -- Ord. Médicale OR Ord. médicale Pédiatrique
+			AND TIMESTAMPDIFF(DAY, DATE_ADD(STR_TO_DATE(CONCAT($P{periods_iso}, '01'), '%Y%m%d'), INTERVAL 1 MONTH), pnv.visit_date) <= 90)
         ) THEN p.patient_id ELSE null END
     ) AS 'maleNumerator',
     COUNT(
@@ -118,10 +126,10 @@ FROM isanteplus.patient p
     LEFT JOIN isanteplus.patient_dispensing pd ON p.patient_id = pd.patient_id,
     isanteplus.org_code_uid org
 WHERE pd.drug_id IN (SELECT drug_id FROM isanteplus.arv_drugs)  -- ART treatment
-    AND p.patient_id NOT IN (   -- Exclude deceased (159), transfer (159492)
+    AND p.patient_id NOT IN (   -- Exclude discontinued (1667), transfer (159492)
         SELECT discon.patient_id
         FROM isanteplus.discontinuation_reason discon
-        WHERE discon.reason IN (159, 159492)
+        WHERE discon.reason IN (1667, 159492)
     ) AND p.patient_id IN (
         SELECT patient_id
         FROM isanteplus.patient_status_arv


### PR DESCRIPTION
Changes:
- Numerator: instead of "pd.next_dispensation_date" use "drug order form completed on date X".
- Denominator: exclude discontinued instead of deceased, HIV+ Patients only